### PR TITLE
Removed forced cookie policy on outgoing messages.

### DIFF
--- a/src/org/mozilla/zest/impl/ZestBasicRunner.java
+++ b/src/org/mozilla/zest/impl/ZestBasicRunner.java
@@ -22,7 +22,6 @@ import org.apache.commons.httpclient.HttpMethod;
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.UsernamePasswordCredentials;
 import org.apache.commons.httpclient.auth.AuthScope;
-import org.apache.commons.httpclient.cookie.CookiePolicy;
 import org.apache.commons.httpclient.methods.DeleteMethod;
 import org.apache.commons.httpclient.methods.GetMethod;
 import org.apache.commons.httpclient.methods.HeadMethod;
@@ -403,7 +402,6 @@ public class ZestBasicRunner implements ZestRunner, ZestRuntime {
 		}
 		method.setURI(new URI(req.getUrl().toString(), true));
 		setHeaders(method, req.getHeaders());
-		method.getParams().setCookiePolicy(CookiePolicy.RFC_2109);
 
 		if (req.getMethod().equals("POST")) {
 			// Do this after setting the headers so the length is corrected


### PR DESCRIPTION
When sending a message, there is no need to force the RFC_2109 Cookie Policy on the method. This cookie policy is the default one and, by not setting it to anything, users can use their own custom policy by setting a custom HttpClient via setHttpClient().
