### PR TITLE
Update Selenium to version 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Update Selenium to version 4.
+
 ### Removed
-- jBrowserDriver (JBD) is no longer supported (no longer being actively maintained).
+- jBrowserDriver (JBD), Opera, and PhantomJS are no longer supported (no longer being actively maintained).
 
 ## [0.16.0] - 2022-10-07
 ### Changed

--- a/build.gradle
+++ b/build.gradle
@@ -28,13 +28,11 @@ dependencies {
     implementation (
              'org.apache.httpcomponents:httpclient:4.5.8',
              'com.google.code.gson:gson:2.8.5',
-             'com.opera:operadriver:1.5',
-             'com.codeborne:phantomjsdriver:1.4.3',
-             'org.seleniumhq.selenium:selenium-server:3.141.59',
-             'org.seleniumhq.selenium:htmlunit-driver:2.36.0',
+             'org.seleniumhq.selenium:selenium-java:4.7.2',
+             'org.seleniumhq.selenium:htmlunit-driver:4.7.2',
              'net.htmlparser.jericho:jericho-html:3.1')
 
-    testImplementation("com.github.tomakehurst:wiremock-jre8:2.33.2") {
+    testImplementation("com.github.tomakehurst:wiremock-jre8:2.35.0") {
         // Not needed.
         exclude(group: "org.junit")
     }

--- a/src/main/java/org/zaproxy/zest/core/v1/ZestClientLaunch.java
+++ b/src/main/java/org/zaproxy/zest/core/v1/ZestClientLaunch.java
@@ -3,12 +3,10 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.zaproxy.zest.core.v1;
 
-import com.opera.core.systems.OperaDriver;
 import java.io.File;
 import java.lang.reflect.Constructor;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayList;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.Proxy;
 import org.openqa.selenium.WebDriver;
@@ -20,8 +18,7 @@ import org.openqa.selenium.firefox.FirefoxProfile;
 import org.openqa.selenium.htmlunit.HtmlUnitDriver;
 import org.openqa.selenium.ie.InternetExplorerDriver;
 import org.openqa.selenium.ie.InternetExplorerOptions;
-import org.openqa.selenium.phantomjs.PhantomJSDriver;
-import org.openqa.selenium.phantomjs.PhantomJSDriverService;
+import org.openqa.selenium.remote.Browser;
 import org.openqa.selenium.remote.CapabilityType;
 import org.openqa.selenium.remote.DesiredCapabilities;
 import org.openqa.selenium.safari.SafariDriver;
@@ -165,8 +162,6 @@ public class ZestClientLaunch extends ZestClient {
         try {
             WebDriver driver = null;
             DesiredCapabilities cap = new DesiredCapabilities();
-            cap.setCapability(CapabilityType.ACCEPT_SSL_CERTS, true);
-            // W3C capability
             cap.setAcceptInsecureCerts(true);
 
             String httpProxy = runtime.getProxy();
@@ -239,17 +234,10 @@ public class ZestClientLaunch extends ZestClient {
 
                 driver = new ChromeDriver(chromeOptions);
             } else if ("HtmlUnit".equalsIgnoreCase(this.browserType)) {
-                driver = new HtmlUnitDriver(DesiredCapabilities.htmlUnit().merge(cap));
+                cap.setBrowserName(Browser.HTMLUNIT.browserName());
+                driver = new HtmlUnitDriver(cap);
             } else if ("InternetExplorer".equalsIgnoreCase(this.browserType)) {
                 driver = new InternetExplorerDriver(new InternetExplorerOptions(cap));
-            } else if ("Opera".equalsIgnoreCase(this.browserType)) {
-                driver = new OperaDriver(cap);
-            } else if ("PhantomJS".equalsIgnoreCase(this.browserType)) {
-                ArrayList<String> cliArgs = new ArrayList<>(2);
-                cliArgs.add("--ssl-protocol=any");
-                cliArgs.add("--ignore-ssl-errors=yes");
-                cap.setCapability(PhantomJSDriverService.PHANTOMJS_CLI_ARGS, cliArgs);
-                driver = new PhantomJSDriver(cap);
             } else if ("Safari".equalsIgnoreCase(this.browserType)) {
                 driver = new SafariDriver(new SafariOptions(cap));
             } else {

--- a/src/main/java/org/zaproxy/zest/impl/ZestBasicRunner.java
+++ b/src/main/java/org/zaproxy/zest/impl/ZestBasicRunner.java
@@ -7,12 +7,13 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.Writer;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Stack;
-import java.util.concurrent.TimeUnit;
 import javax.script.ScriptEngineFactory;
 import org.openqa.selenium.WebDriver;
 import org.zaproxy.zest.core.v1.ZestAction;
@@ -581,7 +582,7 @@ public class ZestBasicRunner implements ZestRunner, ZestRuntime {
     @Override
     public void addWebDriver(String handle, WebDriver wd) {
         webDriverMap.put(handle, wd);
-        wd.manage().timeouts().implicitlyWait(10, TimeUnit.SECONDS);
+        wd.manage().timeouts().implicitlyWait(Duration.of(10, ChronoUnit.SECONDS));
     }
 
     @Override


### PR DESCRIPTION
Update dependencies for newer Selenium version.
Remove support for PhantomJS and Opera which are no longer being supported.
Adjust code to match the new APIs and address a deprecation.