### PR TITLE
Remove `printStackTrace` calls in tests

### DIFF
--- a/src/test/java/org/zaproxy/zest/test/v1/ZestExpressionLengthUnitTest.java
+++ b/src/test/java/org/zaproxy/zest/test/v1/ZestExpressionLengthUnitTest.java
@@ -7,28 +7,26 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.net.MalformedURLException;
 import java.net.URL;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.zaproxy.zest.core.v1.ZestExpressionLength;
 import org.zaproxy.zest.core.v1.ZestResponse;
 
-/** */
+/** Unit test for {@link ZestExpressionLength}. */
 class ZestExpressionLengthUnitTest {
-    static ZestResponse response;
 
-    static {
-        try {
-            response =
-                    new ZestResponse(
-                            new URL("http://this.is.a.test"),
-                            "header prefix12345postfix",
-                            "body prefix54321postfix",
-                            200,
-                            100);
-        } catch (MalformedURLException e) {
-            e.printStackTrace();
-        }
+    private ZestResponse response;
+
+    @BeforeEach
+    void setup() throws Exception {
+        response =
+                new ZestResponse(
+                        new URL("http://this.is.a.test"),
+                        "header prefix12345postfix",
+                        "body prefix54321postfix",
+                        200,
+                        100);
     }
 
     @Test

--- a/src/test/java/org/zaproxy/zest/test/v1/ZestExpressionURLUnitTest.java
+++ b/src/test/java/org/zaproxy/zest/test/v1/ZestExpressionURLUnitTest.java
@@ -7,26 +7,37 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.zaproxy.zest.core.v1.ZestExpressionURL;
 import org.zaproxy.zest.core.v1.ZestRequest;
 import org.zaproxy.zest.core.v1.ZestResponse;
 
-/** */
+/** Unit test for {@link ZestExpressionURL}. */
 class ZestExpressionURLUnitTest {
 
-    List<String> includeStrings = new LinkedList<>();
-    List<String> excludeStrings = new LinkedList<>();
-    int includeSize = 10;
-    int excludeSize = 5;
+    private int includeSize;
+    private List<String> includeStrings;
 
-    {
-        for (int i = 0; i < includeSize; i++) includeStrings.add("PING" + i);
-        for (int i = 0; i < excludeSize; i++) excludeStrings.add("PONG" + i);
+    private int excludeSize;
+    private List<String> excludeStrings;
+
+    @BeforeEach
+    void setup() {
+        includeSize = 10;
+        includeStrings = new ArrayList<>(includeSize);
+        for (int i = 0; i < includeSize; i++) {
+            includeStrings.add("PING" + i);
+        }
+
+        excludeSize = 5;
+        excludeStrings = new ArrayList<>(excludeSize);
+        for (int i = 0; i < excludeSize; i++) {
+            excludeStrings.add("PONG" + i);
+        }
     }
 
     @Test
@@ -47,45 +58,33 @@ class ZestExpressionURLUnitTest {
     }
 
     @Test
-    void testIsTrue() {
+    void testIsTrue() throws Exception {
         ZestExpressionURL urlExpr = new ZestExpressionURL();
         urlExpr.setIncludeRegexes(includeStrings);
         urlExpr.setExcludeRegexes(excludeStrings);
-        try {
-            ZestRequest request = new ZestRequest();
-            request.setUrl(new URL("http://www.PING1.com"));
-            assertTrue(urlExpr.isTrue(new TestRuntime(request)));
-        } catch (MalformedURLException e) {
-            e.printStackTrace();
-        }
+        ZestRequest request = new ZestRequest();
+        request.setUrl(new URL("http://www.PING1.com"));
+        assertTrue(urlExpr.isTrue(new TestRuntime(request)));
     }
 
     @Test
-    void testIsTrueFalse() {
+    void testIsTrueFalse() throws Exception {
         ZestExpressionURL urlExpr = new ZestExpressionURL();
         urlExpr.setIncludeRegexes(includeStrings);
         urlExpr.setExcludeRegexes(excludeStrings);
-        try {
-            ZestRequest request = new ZestRequest();
-            request.setUrl(new URL("http://www.PONG1.com"));
-            assertFalse(urlExpr.isTrue(new TestRuntime(request)));
-        } catch (MalformedURLException e) {
-            e.printStackTrace();
-        }
+        ZestRequest request = new ZestRequest();
+        request.setUrl(new URL("http://www.PONG1.com"));
+        assertFalse(urlExpr.isTrue(new TestRuntime(request)));
     }
 
     @Test
-    void testIsTrueDifferentURL() {
+    void testIsTrueDifferentURL() throws Exception {
         ZestExpressionURL urlExpr = new ZestExpressionURL();
         urlExpr.setIncludeRegexes(includeStrings);
         urlExpr.setExcludeRegexes(excludeStrings);
-        try {
-            ZestRequest request = new ZestRequest();
-            request.setUrl(new URL("http://www.asdf.com"));
-            assertFalse(urlExpr.isTrue(new TestRuntime(request)));
-        } catch (MalformedURLException e) {
-            e.printStackTrace();
-        }
+        ZestRequest request = new ZestRequest();
+        request.setUrl(new URL("http://www.asdf.com"));
+        assertFalse(urlExpr.isTrue(new TestRuntime(request)));
     }
 
     @Test
@@ -155,14 +154,10 @@ class ZestExpressionURLUnitTest {
     }
 
     @Test
-    void testIsTrueExcludePattern() {
-        try {
-            ZestResponse response =
-                    new ZestResponse(new URL("http://www.PONG19874.com"), "", "", 200, 100);
-            ZestExpressionURL urlExpr = new ZestExpressionURL(includeStrings, excludeStrings);
-            assertFalse(urlExpr.isTrue(new TestRuntime(response)));
-        } catch (MalformedURLException e) {
-            e.printStackTrace();
-        }
+    void testIsTrueExcludePattern() throws Exception {
+        ZestResponse response =
+                new ZestResponse(new URL("http://www.PONG19874.com"), "", "", 200, 100);
+        ZestExpressionURL urlExpr = new ZestExpressionURL(includeStrings, excludeStrings);
+        assertFalse(urlExpr.isTrue(new TestRuntime(response)));
     }
 }

--- a/src/test/java/org/zaproxy/zest/test/v1/ZestStructuredExpressionUnitTest.java
+++ b/src/test/java/org/zaproxy/zest/test/v1/ZestStructuredExpressionUnitTest.java
@@ -9,7 +9,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.LinkedList;
 import java.util.List;
@@ -29,7 +28,7 @@ import org.zaproxy.zest.core.v1.ZestResponse;
 import org.zaproxy.zest.core.v1.ZestRuntime;
 import org.zaproxy.zest.core.v1.ZestVariables;
 
-/** */
+/** Unit test for {@link ZestStructuredExpression}. */
 class ZestStructuredExpressionUnitTest {
     @Test
     void testDeepCopySingleAndSameChildrenSize() {
@@ -220,55 +219,49 @@ class ZestStructuredExpressionUnitTest {
     }
 
     @Test
-    void testComplexCondition() {
+    void testComplexCondition() throws Exception {
         ZestExpressionAnd and = new ZestExpressionAnd();
         ZestExpressionOr or = new ZestExpressionOr();
-        try {
-            ZestResponse resp =
-                    new ZestResponse(
-                            new URL("http://this.is.a.test"),
-                            "Header prefix12345postfix",
-                            "Body Prefix54321Postfix",
-                            200,
-                            1000);
-            ZestExpressionLength length =
-                    new ZestExpressionLength(ZestVariables.RESPONSE_BODY, 0, 1);
-            length.setInverse(true);
-            ZestExpressionStatusCode code = new ZestExpressionStatusCode(200);
-            ZestExpressionRegex regex =
-                    new ZestExpressionRegex(ZestVariables.RESPONSE_BODY, "54321");
-            ZestExpressionResponseTime time = new ZestExpressionResponseTime(100);
-            LinkedList<String> includeRegex = new LinkedList<>();
-            LinkedList<String> excludeRegex = new LinkedList<>();
-            excludeRegex.add("");
-            ZestExpressionURL url = new ZestExpressionURL(includeRegex, excludeRegex);
-            url.setInverse(true);
-            time.setGreaterThan(true);
-            ZestExpression genericExp =
-                    new ZestExpression() {
+        ZestResponse resp =
+                new ZestResponse(
+                        new URL("http://this.is.a.test"),
+                        "Header prefix12345postfix",
+                        "Body Prefix54321Postfix",
+                        200,
+                        1000);
+        ZestExpressionLength length = new ZestExpressionLength(ZestVariables.RESPONSE_BODY, 0, 1);
+        length.setInverse(true);
+        ZestExpressionStatusCode code = new ZestExpressionStatusCode(200);
+        ZestExpressionRegex regex = new ZestExpressionRegex(ZestVariables.RESPONSE_BODY, "54321");
+        ZestExpressionResponseTime time = new ZestExpressionResponseTime(100);
+        LinkedList<String> includeRegex = new LinkedList<>();
+        LinkedList<String> excludeRegex = new LinkedList<>();
+        excludeRegex.add("");
+        ZestExpressionURL url = new ZestExpressionURL(includeRegex, excludeRegex);
+        url.setInverse(true);
+        time.setGreaterThan(true);
+        ZestExpression genericExp =
+                new ZestExpression() {
 
-                        @Override
-                        public ZestExpression deepCopy() {
-                            return null;
-                        }
+                    @Override
+                    public ZestExpression deepCopy() {
+                        return null;
+                    }
 
-                        @Override
-                        public boolean isTrue(ZestRuntime runtime) {
-                            return false;
-                        }
-                    };
-            or.addChildCondition(genericExp);
-            and.addChildCondition(length);
-            and.addChildCondition(code);
-            and.addChildCondition(regex);
-            and.addChildCondition(time);
-            and.addChildCondition(url);
-            or.addChildCondition(and);
-            ZestConditional cond = new ZestConditional(or);
-            assertTrue(cond.isTrue(new TestRuntime(resp)));
-        } catch (MalformedURLException e) {
-            e.printStackTrace();
-        }
+                    @Override
+                    public boolean isTrue(ZestRuntime runtime) {
+                        return false;
+                    }
+                };
+        or.addChildCondition(genericExp);
+        and.addChildCondition(length);
+        and.addChildCondition(code);
+        and.addChildCondition(regex);
+        and.addChildCondition(time);
+        and.addChildCondition(url);
+        or.addChildCondition(and);
+        ZestConditional cond = new ZestConditional(or);
+        assertTrue(cond.isTrue(new TestRuntime(resp)));
     }
 
     @Test


### PR DESCRIPTION
Let the exception bubble up instead of (possibly) hiding an error.
For the tests changed use `BeforeEach` to setup the preconditions, more idiomatic than using initialisation blocks.