### PR TITLE
Add Java 21 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [11, 17, 20]
+        java: [11, 17, 21]
 
     steps:
       - uses: actions/checkout@v4

--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,12 @@ test {
     useJUnitPlatform()
 }
 
+tasks.withType(JavaCompile) {
+    if (JavaVersion.current().getMajorVersion() >= "21") {
+        options.compilerArgs = options.compilerArgs + "-Xlint:-this-escape"
+    }
+}
+
 tasks.withType(Javadoc) {
     options {
         links = [ 'https://docs.oracle.com/javase/11/docs/api/' ]


### PR DESCRIPTION
Build with Java 21 which is a LTS version.
Disable the lint `this-escape` to pass the compilation.