### PR TITLE
Allow to invoke scripts with custom engines

### DIFF
--- a/src/main/java/org/zaproxy/zest/core/v1/ZestActionInvoke.java
+++ b/src/main/java/org/zaproxy/zest/core/v1/ZestActionInvoke.java
@@ -108,11 +108,7 @@ public class ZestActionInvoke extends ZestAction {
                 // Its a Zest script
                 engine = runtime.getScriptEngineFactory().getScriptEngine();
             } else {
-                ScriptEngineManager manager = new ScriptEngineManager();
-                engine = manager.getEngineByExtension(ext);
-                if (engine == null) {
-                    engine = manager.getEngineByName(ext);
-                }
+                engine = getScriptEngine(runtime, ext);
             }
         }
 
@@ -195,6 +191,20 @@ public class ZestActionInvoke extends ZestAction {
         } catch (Exception e) {
             throw new ZestActionFailException(this, e);
         }
+    }
+
+    private static ScriptEngine getScriptEngine(ZestRuntime runtime, String ext) {
+        ScriptEngine engine = runtime.getScriptEngine(ext);
+        if (engine != null) {
+            return engine;
+        }
+
+        ScriptEngineManager manager = new ScriptEngineManager();
+        engine = manager.getEngineByExtension(ext);
+        if (engine != null) {
+            return engine;
+        }
+        return manager.getEngineByName(ext);
     }
 
     private Charset getCharsetImpl() {

--- a/src/main/java/org/zaproxy/zest/core/v1/ZestRuntime.java
+++ b/src/main/java/org/zaproxy/zest/core/v1/ZestRuntime.java
@@ -4,6 +4,7 @@
 package org.zaproxy.zest.core.v1;
 
 import java.util.List;
+import javax.script.ScriptEngine;
 import javax.script.ScriptEngineFactory;
 import org.openqa.selenium.WebDriver;
 
@@ -53,6 +54,19 @@ public interface ZestRuntime extends ZestOutputWriter {
      */
     default void setGlobalVariable(String name, String value) {
         // Nothing to do.
+    }
+
+    /**
+     * Gets a {@code ScriptEngine} for the given extension.
+     *
+     * <p>If no engine is returned it is used a default engine, if available.
+     *
+     * @param extension the extension of the script.
+     * @return the {@code ScriptEngine}, or {@code null}.
+     * @since 0.22.0
+     */
+    default ScriptEngine getScriptEngine(String extension) {
+        return null;
     }
 
     /**


### PR DESCRIPTION
Allow the `ZestRuntime` to provide a `ScriptEngine` based on a file extension and change `ZestActionInvoke` to use it, allowing for runtimes to provide their own script engines.