### PR TITLE
Update minimum Java version to 17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [11, 21, 22]
+        java: [17, 21, 22]
 
     steps:
       - uses: actions/checkout@v4
@@ -19,6 +19,6 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
-      - uses: gradle/actions/setup-gradle@v4
+      - uses: gradle/actions/setup-gradle@0bdd871935719febd78681f197cd39af5b6e16a6 # v4.2.2
       - run: ./gradlew assemble
       - run: ./gradlew check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
  - Update Selenium to version 4.28.0.
+ - Update minimum Java version to 17.
 
 ## [0.22.0] - 2024-06-28
 ### Added

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 apply from: "$rootDir/gradle/ci.gradle.kts"
 
 java {
-    def javaVersion = JavaVersion.VERSION_11
+    def javaVersion = JavaVersion.VERSION_17
     sourceCompatibility = javaVersion
     targetCompatibility = javaVersion
 }
@@ -62,7 +62,7 @@ tasks.withType(JavaCompile) {
 
 tasks.withType(Javadoc) {
     options {
-        links = [ 'https://docs.oracle.com/javase/11/docs/api/' ]
+        links = [ "https://docs.oracle.com/en/java/javase/17/docs/api/" ]
         encoding = 'UTF-8'
         source = java.sourceCompatibility
     }


### PR DESCRIPTION
Use the same minimum Java version as the other ZAP projects.
Also, use commit in Gradle GitHub action.