### PR TITLE
Update Jackson and test dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,15 +31,17 @@ dependencies {
              'com.google.code.gson:gson:2.8.5',
              'org.seleniumhq.selenium:selenium-java:4.28.0',
              'org.seleniumhq.selenium:htmlunit3-driver:4.27.0',
-             'net.htmlparser.jericho:jericho-html:3.1',
-             'com.fasterxml.jackson.core:jackson-core:2.15.2',
-             'com.fasterxml.jackson.core:jackson-databind:2.15.2',
-             'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.15.2')
+             'net.htmlparser.jericho:jericho-html:3.1')
 
-    testImplementation("org.wiremock:wiremock:3.6.0")
-    testImplementation('org.mockito:mockito-core:5.12.0')
-    testImplementation("org.assertj:assertj-core:3.26.0")
-    testImplementation("org.junit.jupiter:junit-jupiter:5.10.2")
+    implementation(platform("com.fasterxml.jackson:jackson-bom:2.17.0"))
+    implementation("com.fasterxml.jackson.core:jackson-core")
+    implementation("com.fasterxml.jackson.core:jackson-databind")
+    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml")
+
+    testImplementation("org.wiremock:wiremock:3.10.0")
+    testImplementation("org.mockito:mockito-core:5.15.2")
+    testImplementation("org.assertj:assertj-core:3.27.3")
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 


### PR DESCRIPTION
Use the same Jackson version as in ZAP.
Update test dependencies.