### PR TITLE
Remove workaround no longer needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
  - Update Selenium to version 4.28.1.
+ - Remove workaround that was now causing exceptions.
 
 ## [0.23.0] - 2025-01-23
 ### Changed

--- a/src/main/java/org/zaproxy/zest/core/v1/ZestClientWindowClose.java
+++ b/src/main/java/org/zaproxy/zest/core/v1/ZestClientWindowClose.java
@@ -87,13 +87,6 @@ public class ZestClientWindowClose extends ZestClient {
                 // Ignore, it might have already closed
             }
             runtime.removeWebDriver(getWindowHandle());
-
-            if (runtime.getWebDrivers().size() == 0 && this.getNext() == null) {
-                // We've closed all of the windows and this is the last statement
-                // Explicitly quit - currently needed for the phantomjs driver, otherwise it never
-                // returns :/
-                wd.quit();
-            }
         }
 
         return null;


### PR DESCRIPTION
Remove workaround that's now causing exceptions and it's no longer needed, support for PhantomJS was removed a while ago (#240).