### PR TITLE
Expose the `WebElement` of a `ZestClientElement`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Allow to access the `WebElement` referenced by a `ZestClientElement`.
+
 ### Changed
  - Update Selenium to version 4.31.0.
 

--- a/src/main/java/org/zaproxy/zest/core/v1/ZestClientElement.java
+++ b/src/main/java/org/zaproxy/zest/core/v1/ZestClientElement.java
@@ -49,7 +49,7 @@ public abstract class ZestClientElement extends ZestClient {
         this.element = element;
     }
 
-    protected WebElement getWebElement(ZestRuntime runtime) throws ZestClientFailException {
+    public WebElement getWebElement(ZestRuntime runtime) throws ZestClientFailException {
 
         WebDriver wd = runtime.getWebDriver(this.getWindowHandle());
 


### PR DESCRIPTION
Change the accessibility of the method to allow other code to access the `WebElement` without reimplementing the internal logic of the Zest statement.

---
Related to zaproxy/zap-extensions#6368.