### PR TITLE
Wait for elements to be enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Change `ZestClientElementClick`, `ZestClientElementSendKeys`, and `ZestClientElementSubmit` to wait for the element to also be enabled when using `waitForMsec`.
 
 ## [0.26.0] - 2025-04-25
 ### Added

--- a/src/main/java/org/zaproxy/zest/core/v1/ZestClientElement.java
+++ b/src/main/java/org/zaproxy/zest/core/v1/ZestClientElement.java
@@ -8,6 +8,7 @@ import java.util.function.Supplier;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedCondition;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
@@ -89,13 +90,28 @@ public abstract class ZestClientElement extends ZestClient {
 
             if (this.waitForMsec > 0) {
                 WebDriverWait wait = new WebDriverWait(wd, Duration.ofMillis(waitForMsec));
-                return wait.until(ExpectedConditions.visibilityOfElementLocated(by));
+                return wait.until(getExpectedCondition(by));
             }
             return wd.findElement(by);
 
         } catch (Exception e) {
             throw new ZestClientFailException(this, e);
         }
+    }
+
+    /**
+     * Gets the excepted condition to wait for the element.
+     *
+     * <p>Implementations should override this method to provide a more appropriate condition, by
+     * default it uses {@link ExpectedConditions#visibilityOfElementLocated(By)}.
+     *
+     * @param by the element locator, never {@code null}.
+     * @return the expected condition, should not be {@code null}.
+     * @since 0.27.0
+     * @see #getWaitForMsec()
+     */
+    protected ExpectedCondition<WebElement> getExpectedCondition(By by) {
+        return ExpectedConditions.visibilityOfElementLocated(by);
     }
 
     protected <T extends ZestClientElement> T deepCopy(Supplier<T> t) {

--- a/src/main/java/org/zaproxy/zest/core/v1/ZestClientElementClick.java
+++ b/src/main/java/org/zaproxy/zest/core/v1/ZestClientElementClick.java
@@ -3,6 +3,11 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.zaproxy.zest.core.v1;
 
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedCondition;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+
 /**
  * Click on the specified client element.
  *
@@ -24,6 +29,11 @@ public class ZestClientElementClick extends ZestClientElement {
         this.getWebElement(runtime).click();
 
         return null;
+    }
+
+    @Override
+    protected ExpectedCondition<WebElement> getExpectedCondition(By by) {
+        return ExpectedConditions.elementToBeClickable(by);
     }
 
     @Override

--- a/src/main/java/org/zaproxy/zest/core/v1/ZestClientElementSendKeys.java
+++ b/src/main/java/org/zaproxy/zest/core/v1/ZestClientElementSendKeys.java
@@ -3,6 +3,11 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.zaproxy.zest.core.v1;
 
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedCondition;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+
 /**
  * Send key presses to the specified client element.
  *
@@ -27,6 +32,11 @@ public class ZestClientElementSendKeys extends ZestClientElement {
         String str = runtime.replaceVariablesInString(value, false);
         this.getWebElement(runtime).sendKeys(str);
         return str;
+    }
+
+    @Override
+    protected ExpectedCondition<WebElement> getExpectedCondition(By by) {
+        return ExpectedConditions.elementToBeClickable(by);
     }
 
     public String getValue() {

--- a/src/main/java/org/zaproxy/zest/core/v1/ZestClientElementSubmit.java
+++ b/src/main/java/org/zaproxy/zest/core/v1/ZestClientElementSubmit.java
@@ -3,6 +3,11 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 package org.zaproxy.zest.core.v1;
 
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedCondition;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+
 /**
  * Submit the specified client element.
  *
@@ -28,6 +33,11 @@ public class ZestClientElementSubmit extends ZestClientElement {
     @Override
     public ZestClientElementSubmit deepCopy() {
         return this.deepCopy(ZestClientElementSubmit::new);
+    }
+
+    @Override
+    protected ExpectedCondition<WebElement> getExpectedCondition(By by) {
+        return ExpectedConditions.elementToBeClickable(by);
     }
 
     @Override


### PR DESCRIPTION
Change `ZestClientElementClick`, `ZestClientElementSendKeys`, and `ZestClientElementSubmit` to wait for the element to also be enabled when using `waitForMsec` as this ensures that the element can actually be interacted with (e.g. button is enabled after the username is provided).