### PR TITLE
Click on the position of the obscured element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Change `ZestClientElementClick`, `ZestClientElementSendKeys`, and `ZestClientElementSubmit` to wait for the element to also be enabled when using `waitForMsec`.
 - Update Selenium to version 4.32.0.
+- Change `ZestClientElementClick` to click on the position of the element instead of the element itself when obscured, to better reproduce a manual click.
 
 ## [0.26.0] - 2025-04-25
 ### Added

--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,7 @@ dependencies {
 
     testImplementation("org.wiremock:wiremock:3.10.0")
     testImplementation("org.mockito:mockito-core:5.15.2")
+    testImplementation("org.nanohttpd:nanohttpd-webserver:2.3.1")
     testImplementation("org.assertj:assertj-core:3.27.3")
     testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")

--- a/src/main/java/org/zaproxy/zest/core/v1/ZestClientElementClick.java
+++ b/src/main/java/org/zaproxy/zest/core/v1/ZestClientElementClick.java
@@ -4,7 +4,9 @@
 package org.zaproxy.zest.core.v1;
 
 import org.openqa.selenium.By;
+import org.openqa.selenium.ElementClickInterceptedException;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.interactions.Actions;
 import org.openqa.selenium.support.ui.ExpectedCondition;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 
@@ -26,9 +28,26 @@ public class ZestClientElementClick extends ZestClientElement {
     @Override
     public String invoke(ZestRuntime runtime) throws ZestClientFailException {
 
-        this.getWebElement(runtime).click();
+        WebElement element = getWebElement(runtime);
+        try {
+            element.click();
+        } catch (ElementClickInterceptedException e) {
+            clickOnElementPositon(runtime, element);
+        }
 
         return null;
+    }
+
+    private void clickOnElementPositon(ZestRuntime runtime, WebElement element)
+            throws ZestClientFailException {
+        try {
+            new Actions(runtime.getWebDriver(getWindowHandle()))
+                    .moveToElement(element)
+                    .click()
+                    .perform();
+        } catch (Exception e) {
+            throw new ZestClientFailException(this, e);
+        }
     }
 
     @Override

--- a/src/test/java/org/zaproxy/zest/test/v1/ZestClientElementClickUnitTest.java
+++ b/src/test/java/org/zaproxy/zest/test/v1/ZestClientElementClickUnitTest.java
@@ -1,0 +1,244 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+package org.zaproxy.zest.test.v1;
+
+import static fi.iki.elonen.NanoHTTPD.newFixedLengthResponse;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import fi.iki.elonen.NanoHTTPD.IHTTPSession;
+import fi.iki.elonen.NanoHTTPD.Response;
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.zaproxy.zest.core.v1.ZestClientElementClick;
+import org.zaproxy.zest.core.v1.ZestClientFailException;
+import org.zaproxy.zest.core.v1.ZestClientLaunch;
+import org.zaproxy.zest.core.v1.ZestClientWindowResize;
+import org.zaproxy.zest.core.v1.ZestScript;
+import org.zaproxy.zest.impl.ZestBasicRunner;
+import org.zaproxy.zest.testutils.HTTPDTestServer;
+import org.zaproxy.zest.testutils.NanoServerHandler;
+import org.zaproxy.zest.testutils.ZestTestRunner;
+
+/** Unit test for {@link ZestClientElementClick}. */
+class ZestClientElementClickUnitTest {
+
+    private static final String WINDOW_HANDLE = "windowHandle";
+
+    private static final String PATH_SERVER_FILE = "/test.html";
+    private static final String FORM_SERVER_FILE = "/form.html";
+
+    private static final List<String> BASE_CASES =
+            List.of(
+                    // Simple case.
+                    """
+                    <html>
+                      <body>
+                        <form action="/form.html" method="POST">
+                          <button type="submit" id="login" />
+                        </form>
+                      </body>
+                    </html>
+                    """,
+                    // Out of view.
+                    """
+                    <html>
+                      <head>
+                        <style>
+                          .layer { top: 25000px; left: 25000px; position: absolute; }
+                        </style>
+                      </head>
+                      <body>
+                        <div class="layer">
+                          <form action="/form.html" method="POST">
+                            <button type="submit" id="login" class="layer" />
+                          </form>
+                        </div>
+                      </body>
+                    </html>
+                    """);
+
+    private HTTPDTestServer nano;
+
+    @BeforeEach
+    void startServer() throws IOException {
+        nano = new HTTPDTestServer(0);
+        nano.start();
+    }
+
+    @AfterEach
+    void stopServer() {
+        if (nano != null) {
+            nano.stop();
+        }
+    }
+
+    @Test
+    void shouldNotClickMissingElement() {
+        // Given
+        nano.addHandler(
+                new NanoServerHandler(PATH_SERVER_FILE) {
+                    @Override
+                    protected Response serve(IHTTPSession session) {
+                        return newFixedLengthResponse("<html></html>");
+                    }
+                });
+        ZestScript script = new ZestScript();
+        ZestBasicRunner runner = new ZestTestRunner();
+        script.add(new TestClientLaunch(WINDOW_HANDLE));
+        script.add(new ZestClientElementClick(WINDOW_HANDLE, "id", "missing"));
+
+        // When / Then
+        ZestClientFailException ex =
+                assertThrows(ZestClientFailException.class, () -> runner.run(script, null));
+        assertThat(ex).hasMessageContaining("Unable to locate element: #missing");
+    }
+
+    static Stream<String> baseCases() {
+        return BASE_CASES.stream();
+    }
+
+    @ParameterizedTest
+    @MethodSource("baseCases")
+    void shouldClickElement(String response) throws Exception {
+        // Given
+        nano.addHandler(
+                new NanoServerHandler(PATH_SERVER_FILE) {
+                    @Override
+                    protected Response serve(IHTTPSession session) {
+                        return newFixedLengthResponse(response);
+                    }
+                });
+        AtomicReference<Boolean> formSubmitted = new AtomicReference<>(false);
+        nano.addHandler(
+                new NanoServerHandler(FORM_SERVER_FILE) {
+                    @Override
+                    protected Response serve(IHTTPSession session) {
+                        formSubmitted.set(true);
+                        return newFixedLengthResponse("");
+                    }
+                });
+        ZestScript script = new ZestScript();
+        ZestBasicRunner runner = new ZestTestRunner();
+        script.add(new TestClientLaunch(WINDOW_HANDLE));
+        script.add(new ZestClientElementClick(WINDOW_HANDLE, "id", "login"));
+
+        // When
+        runner.run(script, null);
+
+        // Then
+        assertThat(formSubmitted.get()).isTrue();
+    }
+
+    static Stream<Arguments> resizeCases() {
+        List<Integer> sizes = List.of(0, 1);
+        return BASE_CASES.stream()
+                .flatMap(baseCase -> sizes.stream().map(size -> Arguments.of(baseCase, size)));
+    }
+
+    @ParameterizedTest
+    @MethodSource("resizeCases")
+    void shouldClickElementAfterWindowResize(String response, int size) throws Exception {
+        // Given
+        nano.addHandler(
+                new NanoServerHandler(PATH_SERVER_FILE) {
+                    @Override
+                    protected Response serve(IHTTPSession session) {
+                        return newFixedLengthResponse(response);
+                    }
+                });
+        AtomicReference<Boolean> formSubmitted = new AtomicReference<>(false);
+        nano.addHandler(
+                new NanoServerHandler(FORM_SERVER_FILE) {
+                    @Override
+                    protected Response serve(IHTTPSession session) {
+                        formSubmitted.set(true);
+                        return newFixedLengthResponse("");
+                    }
+                });
+        ZestScript script = new ZestScript();
+        ZestBasicRunner runner = new ZestTestRunner();
+        script.add(new TestClientLaunch(WINDOW_HANDLE));
+        script.add(new ZestClientWindowResize(WINDOW_HANDLE, size, size));
+        script.add(new ZestClientElementClick(WINDOW_HANDLE, "id", "login"));
+
+        // When
+        runner.run(script, null);
+
+        // Then
+        assertThat(formSubmitted.get()).isTrue();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"l2", "l3"})
+    void shouldClickObscuredElement(String element) throws Exception {
+        // Given
+        nano.addHandler(
+                new NanoServerHandler(PATH_SERVER_FILE) {
+                    @Override
+                    protected Response serve(IHTTPSession session) {
+                        return newFixedLengthResponse(
+                                """
+                                <html>
+                                  <head>
+                                    <style>
+                                      .layer { width: 100px; height: 25px; position: absolute; opacity: 0.5; }
+                                      #l1 { background-color: #FF0000; z-index: 3; }
+                                      #l2 { background-color: #00FF00; z-index: 2; }
+                                      #l3 { background-color: #0000FF; z-index: 1; }
+                                    </style>
+                                  </head>
+                                  <body>
+                                    <form action="/form.html" method="POST">
+                                      <button type="submit" id="login">
+                                        <span class="layer" id="l1">Log</span>
+                                        <span class="layer" id="l2">me</span>
+                                        <span class="layer" id="l3">in</span>
+                                      </button>
+                                    </form>
+                                  </body>
+                                </html>
+                                """);
+                    }
+                });
+        AtomicReference<Boolean> formSubmitted = new AtomicReference<>(false);
+        nano.addHandler(
+                new NanoServerHandler(FORM_SERVER_FILE) {
+                    @Override
+                    protected Response serve(IHTTPSession session) {
+                        formSubmitted.set(true);
+                        return newFixedLengthResponse("");
+                    }
+                });
+        ZestScript script = new ZestScript();
+        ZestBasicRunner runner = new ZestTestRunner();
+        script.add(new TestClientLaunch(WINDOW_HANDLE));
+        script.add(new ZestClientElementClick(WINDOW_HANDLE, "id", element));
+
+        // When
+        runner.run(script, null);
+
+        // Then
+        assertThat(formSubmitted.get()).isTrue();
+    }
+
+    private class TestClientLaunch extends ZestClientLaunch {
+
+        TestClientLaunch(String windowHandle) {
+            super(
+                    windowHandle,
+                    "firefox",
+                    "http://localhost:" + nano.getListeningPort() + PATH_SERVER_FILE);
+        }
+    }
+}

--- a/src/test/java/org/zaproxy/zest/testutils/HTTPDTestServer.java
+++ b/src/test/java/org/zaproxy/zest/testutils/HTTPDTestServer.java
@@ -1,0 +1,59 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+package org.zaproxy.zest.testutils;
+
+import fi.iki.elonen.NanoHTTPD;
+import java.util.ArrayList;
+import java.util.List;
+
+public class HTTPDTestServer extends NanoHTTPD {
+
+    private List<NanoServerHandler> handlers = new ArrayList<>();
+    private List<String> requestedUris = new ArrayList<>();
+
+    private NanoServerHandler handler404 =
+            new NanoServerHandler("") {
+                @Override
+                protected Response serve(IHTTPSession session) {
+                    consumeBody(session);
+                    return newFixedLengthResponse(
+                            Response.Status.NOT_FOUND,
+                            MIME_HTML,
+                            "<html><head><title>404</title></head><body>404 Not Found</body></html>");
+                }
+            };
+
+    public HTTPDTestServer(int port) {
+        super(port);
+    }
+
+    public List<String> getRequestedUris() {
+        return requestedUris;
+    }
+
+    @Override
+    public Response serve(IHTTPSession session) {
+        String uri = session.getUri();
+        requestedUris.add(uri);
+
+        for (NanoServerHandler handler : handlers) {
+            if (uri.startsWith(handler.getName())) {
+                return handler.serve(session);
+            }
+        }
+        return handler404.serve(session);
+    }
+
+    public void addHandler(NanoServerHandler handler) {
+        this.handlers.add(handler);
+    }
+
+    public void removeHandler(NanoServerHandler handler) {
+        this.handlers.remove(handler);
+    }
+
+    public void setHandler404(NanoServerHandler handler) {
+        this.handler404 = handler;
+    }
+}

--- a/src/test/java/org/zaproxy/zest/testutils/NanoServerHandler.java
+++ b/src/test/java/org/zaproxy/zest/testutils/NanoServerHandler.java
@@ -1,0 +1,101 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+package org.zaproxy.zest.testutils;
+
+import fi.iki.elonen.NanoHTTPD.IHTTPSession;
+import fi.iki.elonen.NanoHTTPD.Response;
+import java.io.IOException;
+import org.apache.commons.io.IOUtils;
+
+public abstract class NanoServerHandler {
+
+    private String name;
+
+    public NanoServerHandler(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    protected abstract Response serve(IHTTPSession session);
+
+    /**
+     * Consumes the request body.
+     *
+     * @param session the session that has the request
+     */
+    protected void consumeBody(IHTTPSession session) {
+        try {
+            session.getInputStream().skip(getBodySize(session));
+        } catch (IOException e) {
+            System.err.println("Failed to consume body:");
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Gets the size of the request body.
+     *
+     * @param session the session that has the request
+     * @return the size of the body
+     */
+    protected int getBodySize(IHTTPSession session) {
+        String contentLengthHeader = session.getHeaders().get("content-length");
+        if (contentLengthHeader == null) {
+            return 0;
+        }
+
+        int contentLength = 0;
+        try {
+            contentLength = Integer.parseInt(contentLengthHeader);
+        } catch (NumberFormatException e) {
+            System.err.println("Failed to parse content-length value: " + contentLengthHeader);
+            e.printStackTrace();
+            return 0;
+        }
+
+        if (contentLength <= 0) {
+            return 0;
+        }
+        return contentLength;
+    }
+
+    /**
+     * Gets the request body.
+     *
+     * @param session the session that has the request
+     * @return the body
+     */
+    public String getBody(IHTTPSession session) {
+        int contentLength = getBodySize(session);
+        if (contentLength == 0) {
+            return "";
+        }
+
+        byte[] bytes = new byte[contentLength];
+        try {
+            IOUtils.readFully(session.getInputStream(), bytes);
+        } catch (IOException e) {
+            System.err.println("Failed to read the body:");
+            e.printStackTrace();
+            return "";
+        }
+        return new String(bytes);
+    }
+
+    /**
+     * Gets the first parameter which is contained in the parameters list
+     *
+     * @param session the session that has the request
+     * @param param the parameter name
+     * @return the first value of the parameters
+     */
+    protected static String getFirstParamValue(IHTTPSession session, String param) {
+        return session.getParameters().get(param) != null
+                ? session.getParameters().get(param).get(0)
+                : null;
+    }
+}

--- a/src/test/java/org/zaproxy/zest/testutils/ZestTestRunner.java
+++ b/src/test/java/org/zaproxy/zest/testutils/ZestTestRunner.java
@@ -1,0 +1,43 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+package org.zaproxy.zest.testutils;
+
+import java.io.IOException;
+import java.util.Map;
+import org.zaproxy.zest.core.v1.ZestActionFailException;
+import org.zaproxy.zest.core.v1.ZestAssertFailException;
+import org.zaproxy.zest.core.v1.ZestAssignFailException;
+import org.zaproxy.zest.core.v1.ZestClientFailException;
+import org.zaproxy.zest.core.v1.ZestInvalidCommonTestException;
+import org.zaproxy.zest.core.v1.ZestRequest;
+import org.zaproxy.zest.core.v1.ZestScript;
+import org.zaproxy.zest.impl.ZestBasicRunner;
+
+/** A {@link ZestBasicRunner} that quits the browsers that might have been launched. */
+public class ZestTestRunner extends ZestBasicRunner {
+
+    @Override
+    public String run(ZestScript script, ZestRequest target, Map<String, String> tokens)
+            throws ZestAssertFailException,
+                    ZestActionFailException,
+                    ZestInvalidCommonTestException,
+                    IOException,
+                    ZestAssignFailException,
+                    ZestClientFailException {
+
+        try {
+            return super.run(script, target, tokens);
+        } finally {
+            getWebDrivers()
+                    .forEach(
+                            wd -> {
+                                try {
+                                    wd.quit();
+                                } catch (Exception ignore) {
+                                    // Nothing to do, finished running.
+                                }
+                            });
+        }
+    }
+}


### PR DESCRIPTION
Change `ZestClientElementClick` to click on the position of the element instead of the element itself when obscured, to better reproduce a manual click.