### PR TITLE
Scroll to element only when needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Change `ZestClientElementScrollTo` to only scroll to the element when not already in view.
 
 ## [0.27.0] - 2025-05-09
 ### Changed

--- a/src/main/java/org/zaproxy/zest/core/v1/ZestClientElementScrollTo.java
+++ b/src/main/java/org/zaproxy/zest/core/v1/ZestClientElementScrollTo.java
@@ -4,7 +4,9 @@
 package org.zaproxy.zest.core.v1;
 
 import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.WebElement;
 
+/** A client element statement that scrolls to the element, if it's not already in view. */
 public class ZestClientElementScrollTo extends ZestClientElement {
 
     public ZestClientElementScrollTo(String sessionIdName, String type, String element) {
@@ -19,10 +21,32 @@ public class ZestClientElementScrollTo extends ZestClientElement {
     public String invoke(ZestRuntime runtime) throws ZestClientFailException {
 
         JavascriptExecutor js = (JavascriptExecutor) runtime.getWebDriver(getWindowHandle());
-        String script = "arguments[0].scrollIntoView();";
-        js.executeScript(script, getWebElement(runtime));
+
+        if (!isElementInView(js, getWebElement(runtime))) {
+            String script = "arguments[0].scrollIntoView();";
+            js.executeScript(script, getWebElement(runtime));
+        }
 
         return null;
+    }
+
+    private boolean isElementInView(JavascriptExecutor js, WebElement element) {
+        // Sourced from:
+        // https://gist.github.com/davidtheclark/5515733#gistcomment-2113205
+        return (boolean)
+                js.executeScript(
+                        """
+                        const rect = arguments[0].getBoundingClientRect()
+
+                        const windowHeight = (window.innerHeight || document.documentElement.clientHeight)
+                        const windowWidth = (window.innerWidth || document.documentElement.clientWidth)
+
+                        const vertInView = (rect.top <= windowHeight) && ((rect.top + rect.height) > 0)
+                        const horInView = (rect.left <= windowWidth) && ((rect.left + rect.width) > 0)
+
+                        return (vertInView && horInView)
+                        """,
+                        element);
     }
 
     @Override

--- a/src/test/java/org/zaproxy/zest/test/v1/ZestClientElementScrollToUnitTest.java
+++ b/src/test/java/org/zaproxy/zest/test/v1/ZestClientElementScrollToUnitTest.java
@@ -100,6 +100,31 @@ class ZestClientElementScrollToUnitTest extends ServerBasedTest {
     }
 
     @Test
+    void shouldNotScrollToElementWhenInView() throws Exception {
+        // Given
+        String htmlContent =
+                "<html><head></head><body style='height: 2000px;'><div style='height: 100px;'></div><p id=\"test-id\">Paragraph</p></body></html>";
+        server.stubFor(
+                get(urlEqualTo(PATH_SERVER_FILE))
+                        .willReturn(aResponse().withStatus(200).withBody(htmlContent)));
+        ZestScript script = new ZestScript();
+        ZestBasicRunner runner = new ZestBasicRunner();
+        script.add(new ZestClientLaunch("windowHandle", "firefox", getServerUrl(PATH_SERVER_FILE)));
+        script.add(new ZestClientElementScrollTo("windowHandle", "id", "test-id"));
+
+        // When
+        runner.run(script, null);
+
+        // Then
+        WebDriver driver = runner.getWebDriver("windowHandle");
+        JavascriptExecutor jsExecutor = (JavascriptExecutor) driver;
+        long scrollY = (long) jsExecutor.executeScript("return window.scrollY;");
+        driver.quit();
+        // Zero means no scroll happened
+        assertThat(scrollY).isZero();
+    }
+
+    @Test
     void shouldDeepCopy() {
         // Given
         ZestClientElementScrollTo original =


### PR DESCRIPTION
Only scroll to the element if not in view, this prevents unnecessary scrolling which could cause other elements (e.g. fixed headers) to hide the element (and break further interactions).