### PR TITLE
Update repo URLs to Central Portal

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,8 +97,8 @@ task sourcesJar(type: Jar) {
 publishing {
     repositories {
         maven {
-            def releasesRepoUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
-            def snapshotsRepoUrl = "https://oss.sonatype.org/content/repositories/snapshots/"
+            def releasesRepoUrl = "https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/"
+            def snapshotsRepoUrl = "https://central.sonatype.com/repository/maven-snapshots/"
             url = version.endsWith("SNAPSHOT") ? snapshotsRepoUrl : releasesRepoUrl
 
             if (project.hasProperty('ossrhUsername') && project.hasProperty('ossrhPassword')) {


### PR DESCRIPTION
Publish through Central Portal (OSSRH Staging API) instead of deprecated OSSRH.